### PR TITLE
Fix: cli should switch to local version properly

### DIFF
--- a/bin/ris.js
+++ b/bin/ris.js
@@ -8,6 +8,7 @@ const path = require('path')
 const chalk = require('chalk')
 const fs = require('fs-extra')
 const createDebug = require('debug')
+const globalPrefix = require('global-prefix')
 const { CWD, LOCAL_VERSION_PATH, PACKAGE_JSON_PATH } = require('../src/constants')
 
 const RunPluginScriptCommand = require('../src/commands/runPluginScript')
@@ -20,7 +21,6 @@ const CommitCommand = require('../src/commands/commit')
 const AssembleCommand = require('../src/commands/assemble')
 const CleanCacheCommand = require('../src/commands/cleanCache')
 const ReleaseCommand = require('../src/commands/release')
-const globalPrefix = require('global-prefix')
 
 const commands = [
   RunPluginScriptCommand,

--- a/bin/ris.js
+++ b/bin/ris.js
@@ -91,7 +91,7 @@ const getYarnPrefix = () => {
     return path.join(process.env.LOCALAPPDATA, 'Yarn', 'config', 'global')
   }
 
-  return path.join(os.homedir(), 'config', 'yarn', 'global')
+  return path.join(os.homedir(), '.config', 'yarn', 'global')
 }
 
 const inGlobalYarn = fullpath => fullpath.indexOf(getYarnPrefix()) === 0

--- a/bin/ris.js
+++ b/bin/ris.js
@@ -92,7 +92,7 @@ const inGlobalModules = fullpath => {
 }
 
 const isGlobalRun = () => {
-  const execPath = fs.realpathSync(process.argv[1]);
+  const execPath = fs.realpathSync(process.argv[1])
 
   return inGlobalModules(execPath)
 }

--- a/bin/ris.js
+++ b/bin/ris.js
@@ -172,28 +172,12 @@ const canRunPlugin = () => {
   return false
 }
 
-const runLocalVersion = args => {
-  console.log(chalk.bold.green('Switch to use local package version'))
+const runLocalVersion = (execPath, args) => {
+  console.log(chalk.bold.green('Switch to use local version'))
 
   const result = spawn.sync(
-    LOCAL_VERSION_PATH,
+    execPath,
     args,
-    {
-      cwd: process.cwd(),
-      stdio: 'inherit',
-    }
-  ).status
-
-  process.exit(result)
-}
-
-const runPluginVersion = args => {
-  console.log(chalk.bold.green('Switch to use local plugin version'))
-  const localPluginPath = readLocalPluginPath()
-
-  const result = spawn.sync(
-    'node',
-    [localPluginPath].concat(args),
     {
       cwd: process.cwd(),
       stdio: 'inherit',
@@ -208,9 +192,11 @@ const args = process.argv.slice(2)
 const globalRun = isGlobalRun()
 
 if (globalRun && canRunLocalVersion()) {
-  runLocalVersion(args)
+  // Run local version from node_modules directly - on Windows it will be shell script, on other systems - js file with execute permission
+  runLocalVersion(LOCAL_VERSION_PATH, args)
 } else if (globalRun && canRunPlugin()) {
-  runPluginVersion(args)
+  // Run local version from plugin with node - on all systems it will be js file
+  runLocalVersion('node', [readLocalPluginPath()].concat(args))
 } else {
   runCommand(args)
 }

--- a/bin/ris.js
+++ b/bin/ris.js
@@ -20,6 +20,7 @@ const CommitCommand = require('../src/commands/commit')
 const AssembleCommand = require('../src/commands/assemble')
 const CleanCacheCommand = require('../src/commands/cleanCache')
 const ReleaseCommand = require('../src/commands/release')
+const globalPrefix = require('global-prefix')
 
 const commands = [
   RunPluginScriptCommand,
@@ -83,10 +84,17 @@ const runCommand = ([firstArg = '', ...args]) => {
   })).catch(handleError)
 }
 
+const inGlobalModules = fullpath => {
+  // Check if script is executed from yarn global dir
+  const isYarnGlobal = fullpath.indexOf(['config', 'global', 'node_modules'].join(path.sep)) >= 0
+
+  return fullpath.indexOf(globalPrefix) === 0 || isYarnGlobal
+}
+
 const isGlobalRun = () => {
-  const execPath = process.argv[1]
-  return execPath.indexOf(['node_modules', '.bin'].join(path.sep)) === -1 &&
-    execPath.indexOf(['node_modules', '@rispa', 'cli'].join(path.sep)) === -1
+  const execPath = fs.realpathSync(process.argv[1]);
+
+  return inGlobalModules(execPath)
 }
 
 const canRunLocalVersion = () => {

--- a/bin/ris.js
+++ b/bin/ris.js
@@ -123,8 +123,8 @@ const runLocalVersion = args => {
   console.log(chalk.bold.green('Switch to use local version'))
 
   const result = spawn.sync(
-    'node',
-    [LOCAL_VERSION_PATH].concat(args),
+    LOCAL_VERSION_PATH,
+    args,
     {
       cwd: process.cwd(),
       stdio: 'inherit',

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "figures": "^2.0.0",
     "fs-extra": "^3.0.1",
     "glob": "^7.1.2",
+    "global-prefix": "^1.0.1",
     "inquirer": "^3.0.6",
     "listr": "^0.12.0",
     "sudo-block": "^1.2.0"

--- a/src/constants.js
+++ b/src/constants.js
@@ -28,6 +28,7 @@ const SKIP_REASONS = {
   [TEST_MODE]: 'Testing mode',
 }
 const ALL_PLUGINS = 'all'
+const CLI_PLUGIN_NAME = 'rispa-cli'
 
 module.exports = {
   CWD,
@@ -55,4 +56,5 @@ module.exports = {
   ALL_PLUGINS,
   DEFAULT_PLUGIN_BRANCH,
   DEFAULT_PLUGIN_DEV_BRANCH,
+  CLI_PLUGIN_NAME,
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1013,6 +1013,12 @@ expand-range@^1.8.1:
   dependencies:
     fill-range "^2.1.0"
 
+expand-tilde@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/expand-tilde/-/expand-tilde-2.0.2.tgz#97e801aa052df02454de46b02bf621642cdc8502"
+  dependencies:
+    homedir-polyfill "^1.0.1"
+
 extend@^3.0.0, extend@~3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.1.tgz#a755ea7bc1adfcc5a31ce7e762dbaadc5e636444"
@@ -1214,6 +1220,32 @@ glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.1.1, glob@^7.1.2:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
+global-modules@^0.2.3:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/global-modules/-/global-modules-0.2.3.tgz#ea5a3bed42c6d6ce995a4f8a1269b5dae223828d"
+  dependencies:
+    global-prefix "^0.1.4"
+    is-windows "^0.2.0"
+
+global-prefix@^0.1.4:
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/global-prefix/-/global-prefix-0.1.5.tgz#8d3bc6b8da3ca8112a160d8d496ff0462bfef78f"
+  dependencies:
+    homedir-polyfill "^1.0.0"
+    ini "^1.3.4"
+    is-windows "^0.2.0"
+    which "^1.2.12"
+
+global-prefix@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/global-prefix/-/global-prefix-1.0.1.tgz#5f88aa159fef523834e698b854fe78a7e1125adb"
+  dependencies:
+    homedir-polyfill "^1.0.1"
+    ini "^1.3.4"
+    is-windows "^1.0.1"
+    resolve-dir "^1.0.0"
+    which "^1.2.14"
+
 globals@^9.0.0, globals@^9.14.0:
   version "9.17.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-9.17.0.tgz#0c0ca696d9b9bb694d2e5470bd37777caad50286"
@@ -1304,6 +1336,12 @@ home-or-tmp@^2.0.0:
     os-homedir "^1.0.0"
     os-tmpdir "^1.0.1"
 
+homedir-polyfill@^1.0.0, homedir-polyfill@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz#4c2bbc8a758998feebf5ed68580f76d46768b4bc"
+  dependencies:
+    parse-passwd "^1.0.0"
+
 hosted-git-info@^2.1.4:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.4.2.tgz#0076b9f46a270506ddbaaea56496897460612a67"
@@ -1358,6 +1396,10 @@ inflight@^1.0.4:
 inherits@2, inherits@^2.0.3, inherits@~2.0.1:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
+
+ini@^1.3.4:
+  version "1.3.4"
+  resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.4.tgz#0537cb79daf59b59a1a517dff706c86ec039162e"
 
 inquirer@^0.12.0:
   version "0.12.0"
@@ -1590,6 +1632,14 @@ is-upper-case@^1.1.0:
 is-utf8@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72"
+
+is-windows@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-0.2.0.tgz#de1aa6d63ea29dd248737b69f1ff8b8002d2108c"
+
+is-windows@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.1.tgz#310db70f742d259a16a369202b51af84233310d9"
 
 isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
@@ -2395,6 +2445,10 @@ parse-json@^2.2.0:
   dependencies:
     error-ex "^1.2.0"
 
+parse-passwd@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/parse-passwd/-/parse-passwd-1.0.0.tgz#6d5b934a456993b23d37f40a382d6f1666a8e5c6"
+
 parse5@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/parse5/-/parse5-1.5.1.tgz#9b7f3b0de32be78dc2401b17573ccaf0f6f59d94"
@@ -2652,6 +2706,13 @@ require-uncached@^1.0.2:
   dependencies:
     caller-path "^0.1.0"
     resolve-from "^1.0.0"
+
+resolve-dir@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/resolve-dir/-/resolve-dir-1.0.0.tgz#77a1b8f9197a60e7733b4f0d977e69ccd9b5fd86"
+  dependencies:
+    expand-tilde "^2.0.0"
+    global-modules "^0.2.3"
 
 resolve-from@^1.0.0:
   version "1.0.1"
@@ -3136,7 +3197,7 @@ which-module@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/which-module/-/which-module-1.0.0.tgz#bba63ca861948994ff307736089e3b96026c2a4f"
 
-which@^1.2.12, which@^1.2.9:
+which@^1.2.12, which@^1.2.14, which@^1.2.9:
   version "1.2.14"
   resolved "https://registry.yarnpkg.com/which/-/which-1.2.14.tgz#9a87c4378f03e827cecaf1acdf56c736c01c14e5"
   dependencies:


### PR DESCRIPTION
![](https://github.trello.services/images/mini-trello-icon.png) [cli should switch to local version propertly](https://trello.com/c/yX6CBY2f/78-cli-should-switch-to-local-version-propertly)
Изменил логику, чтобы проверялось нахождение запущенного скрипта в директории, куда устанавливаются глобальные модули. Для npm использовал пакет global-prefix, для yarn похожего не нашёл - сделал проверку на наличие в пути используемой yarn на всех платформах структуры папок `config/global/node_modules`.